### PR TITLE
Add optional motivational messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ A interação com o JIRA é feita a partir do recurso de AUTOMATION (automatiza�
 1. When: `Quando uma issue for movida para {SELECIONE AS ETAPAS DE FLUXO QUE ESTÃO DEPOIS DO PONTO DE COMPROMISSO E ANTES DO DONE}`
 2. Then: `Enviar um WEB REQUEST {web request URL é onde você publicou seu BOT, e o HTTP Method é POST}`
 
+Endpoint de Progresso
+---------------------
+
+Envie POST para `/check_progress_status` com `team_id`, `epic_id` e `label`.
+Se desejar omitir a mensagem motivacional gerada via GPT, inclua `BOTMESSAGE=0`
+no payload. Sem esse parâmetro, o bot enviará a mensagem motivacional
+automaticamente.
+
 
 Contribuindo para o JAY
 -----------------------

--- a/app.py
+++ b/app.py
@@ -28,9 +28,11 @@ def progress_status_check():
     team_id = data["team_id"]
     epic_id = data['epic_id']
     label = data['label']
+    botmessage_flag = str(data.get('BOTMESSAGE', '1'))
+    send_bot_message = botmessage_flag != '0'
 
     try:
-        check_progress_status(team_id, epic_id, label)
+        check_progress_status(team_id, epic_id, label, send_bot_message)
     except Exception as e:
         logger.error("Erro ao verificar progresso: %s", e)
         return jsonify({"error": "Erro ao processar webhook"}), 500

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -7,8 +7,14 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def check_progress_status(team_id, epic_id, label):
-    """Consulta o progresso do épico no JIRA e envia um relatório para o Slack."""
+def check_progress_status(team_id, epic_id, label, send_bot_message=True):
+    """Consulta o progresso do épico no JIRA e envia um relatório para o Slack.
+
+    :param team_id: ID do time
+    :param epic_id: ID do épico
+    :param label: label do marco para busca
+    :param send_bot_message: Indica se deve anexar mensagem motivacional
+    """
     config = get_config()
     teams_config = load_json_file('teams_config.json')
 
@@ -40,18 +46,19 @@ def check_progress_status(team_id, epic_id, label):
         percent_complete = (done_issues / total_issues) * 100 if total_issues > 0 else 0
         progress_bar = create_progress_bar(percent_complete)
 
-        # Gerar mensagem motivacional
-        mensagem_motivacional = gerar_mensagem_motivacional(percent_complete)
-
         # Enviar para Slack
         message = (
             f"📊 *Progresso do {label}*\n"
             f"🗂️ Épico: {epic_display}\n"
             f"- Total de Tarefas: {total_issues}\n"
             f"- Concluídas: {done_issues} ({percent_complete:.2f}%)\n"
-            f"- Progresso: {progress_bar}\n\n"
-            f"🎉 {mensagem_motivacional}"
+            f"- Progresso: {progress_bar}"
         )
+
+        if send_bot_message:
+            mensagem_motivacional = gerar_mensagem_motivacional(percent_complete)
+            message += f"\n\n🎉 {mensagem_motivacional}"
+
         slack_client.send_message(channel=team_config['channel'], message=message)
     except Exception as e:
         logger.error("Erro ao verificar progresso do épico %s: %s", epic_id, e)


### PR DESCRIPTION
## Summary
- allow disabling GPT motivational messages via `BOTMESSAGE=0`
- document progress endpoint parameter in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68405e2b20ac832aa05799791468ca16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Novos Recursos**
  - Adicionado parâmetro opcional para suprimir a mensagem motivacional ao consultar o progresso via endpoint `/check_progress_status`. Agora é possível controlar se a mensagem motivacional será enviada ou não.
- **Documentação**
  - Atualização do README para documentar o novo parâmetro do endpoint e seu funcionamento.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->